### PR TITLE
Fixed the language requesting on Web

### DIFF
--- a/lib/src/language_tool.dart
+++ b/lib/src/language_tool.dart
@@ -93,7 +93,7 @@ class LanguageTool {
   }
 
   /// Get a list of supported languages.
-  Future<List<Language>?> languages() async {
+  Future<List<Language>> languages() async {
     final res = await http.get(
       Uri.https(_url, 'v2/languages'),
       headers: {'Accept': 'application/json'},

--- a/lib/src/language_tool.dart
+++ b/lib/src/language_tool.dart
@@ -96,7 +96,7 @@ class LanguageTool {
   Future<List<Language>?> languages() async {
     final res = await http.get(
       Uri.https(_url, 'v2/languages'),
-      headers: {'content-type': 'application/json'},
+      headers: {'Accept': 'application/json'},
     );
 
     if (res.statusCode != 200) {


### PR DESCRIPTION
## Status

**READY**

## Description

I have changed the `Content-Type` header in the `languages` method, which prevented the languages fetching on the Web, to the `Accept` header.
Also, I've removed the unnecessary nullability of the result of the `languages` method, as the result can never be null.

## Type of Change

- [ ] ✨ New feature (non-breaking change which adds functionality)
- [x] 🛠️ Bug fix (non-breaking change which fixes an issue)
- [ ] ❌ Breaking change (fix or feature that would cause existing functionality to change)
- [ ] 🧹 Code refactor
- [ ] ✅ Build configuration change
- [ ] 📝 Documentation
- [ ] 🗑️ Chore
